### PR TITLE
Filter slack messages for theme creation events

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -228,12 +228,7 @@ ${CLEANED_ERRORS}
       echo "⚠️ Failed to post success comment"
     fi
     
-    # Send Slack notification
-    if [ -n "$THEME_ERRORS" ]; then
-      send_slack_notification "warning" "Theme updated with warnings:\n${CLEANED_ERRORS}" "$PREVIEW_URL" "$EXISTING_THEME_ID"
-    else
-      send_slack_notification "success" "Theme updated successfully!" "$PREVIEW_URL" "$EXISTING_THEME_ID"
-    fi
+    # No Slack notification for theme updates
     
     # Set outputs for GitHub Action
     echo "theme-id=${EXISTING_THEME_ID}" >> "$GITHUB_OUTPUT"
@@ -251,8 +246,7 @@ ${CLEANED_ERRORS}
       echo "❌ Failed to update existing theme"
       post_error_comment "$THEME_ERRORS" "$EXISTING_THEME_ID"
       
-      cleaned_errors=$(clean_for_slack "$THEME_ERRORS")
-      send_slack_notification "error" "Failed to update existing theme:\n${cleaned_errors}" "" "$EXISTING_THEME_ID"
+      # No Slack notification for theme update failures
       exit 1
     fi
   fi


### PR DESCRIPTION
Remove Slack notifications for theme updates to only send messages for new theme creation or creation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-c249b927-4b10-43bc-a5ff-d162130c4f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c249b927-4b10-43bc-a5ff-d162130c4f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Slack notifications for theme update successes, warnings, and errors.
  * Users will no longer receive Slack alerts during theme update deployments.
  * CI/CD continues to run as before; only Slack side-effects are removed.
  * Post-deploy comments and GitHub outputs are unaffected.
  * No UI or feature changes in the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->