### PR TITLE
fix: preserve special chars in theme names during eval

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,17 +114,20 @@ echo "📝 Theme name: ${THEME_NAME}"
 # Find existing theme information from PR comments
 echo "🔍 Checking for existing theme..."
 
-# Fetch comments and theme list in parallel for better performance
-{
-  COMMENTS=$(fetch_pr_comments "$PR_NUMBER") &
-  COMMENTS_PID=$!
-  
-  THEME_LIST_JSON=$(shopify theme list --json 2>/dev/null) &
-  THEME_LIST_PID=$!
-} 2>/dev/null
+# Fetch comments and theme list in parallel using temp files
+# (variable assignments inside backgrounded subshells don't propagate)
+COMMENTS_TMP=$(mktemp)
+THEME_LIST_TMP=$(mktemp)
+trap 'rm -f "$COMMENTS_TMP" "$THEME_LIST_TMP"' EXIT
 
-# Wait for both operations to complete
+fetch_pr_comments "$PR_NUMBER" > "$COMMENTS_TMP" &
+COMMENTS_PID=$!
+shopify theme list --json > "$THEME_LIST_TMP" 2>/dev/null &
+THEME_LIST_PID=$!
+
 wait $COMMENTS_PID $THEME_LIST_PID 2>/dev/null || true
+COMMENTS=$(cat "$COMMENTS_TMP")
+THEME_LIST_JSON=$(cat "$THEME_LIST_TMP")
 
 # Extract theme ID from comments if exists
 if [ -n "$COMMENTS" ]; then

--- a/scripts/lib/theme.sh
+++ b/scripts/lib/theme.sh
@@ -237,7 +237,7 @@ upload_theme() {
   # Never overwrite: config/settings_data.json, templates/*.json, sections/*.json, layout/*.json
   if [ "$include_json" = "false" ]; then
     echo "📤 Uploading theme to ID: ${theme_id} (preserving settings, always pushing locale & schema from codebase)..."
-    set +e
+    set +e -f
     OUTPUT=$(eval shopify theme push \
       --theme \"$theme_id\" \
       --path \"$theme_path\" \
@@ -250,10 +250,10 @@ upload_theme() {
       --ignore=\"layout/*.json\" \
       $custom_ignore_flags 2>&1)
     status=$?
-    set -e
+    set -e +f
   else
     echo "📤 Uploading theme to ID: ${theme_id}..."
-    set +e
+    set +e -f
     OUTPUT=$(eval shopify theme push \
       --theme \"$theme_id\" \
       --path \"$theme_path\" \
@@ -262,7 +262,7 @@ upload_theme() {
       --json \
       $custom_ignore_flags 2>&1)
     status=$?
-    set -e
+    set -e +f
   fi
   
   LAST_UPLOAD_OUTPUT="$OUTPUT"
@@ -330,7 +330,7 @@ create_theme_with_retry() {
       echo "🎨 Creating new theme: ${theme_name} (attempt $((attempt + 1)))"
 
       local status=0
-      set +e
+      set +e -f
       OUTPUT=$(eval shopify theme push \
         --unpublished \
         --theme \"${theme_name}\" \
@@ -340,7 +340,7 @@ create_theme_with_retry() {
         --json \
         $custom_ignore_flags 2>&1)
       status=$?
-      set -e
+      set -e +f
 
       LAST_UPLOAD_OUTPUT="$OUTPUT"
       


### PR DESCRIPTION
## Summary
- Theme names with brackets (e.g. `[MNC-944]`) and underscores were being mangled by shell glob expansion during `eval` in `theme.sh`
- `[MNC-944] Add short_title` became `MNC944 Add shorttitle` in Shopify admin
- Root cause: commit 9f331f1 added `eval` + escaped quotes, but `eval` expands the variable before quoting — so `[MNC-944]` is treated as a glob pattern
- Fix: wrap each `eval` block with `set -f` (disable globbing) / `set +f` (re-enable)

## Test plan
- [ ] Create a PR with brackets and underscores in the title (e.g. `[MNC-123] Test_name`)
- [ ] Verify the Shopify theme name in the admin matches exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MNC-944]: https://shoplab.atlassian.net/browse/MNC-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNC-944]: https://shoplab.atlassian.net/browse/MNC-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNC-944]: https://shoplab.atlassian.net/browse/MNC-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNC-123]: https://shoplab.atlassian.net/browse/MNC-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of theme upload operations to better handle transient errors and shell behavior.
  * Made deployment steps more reliable by running concurrent data fetches with temporary persistence and ensured proper cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShopLab-Team/shoplab-pr-shopify-theme-preview/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->