### PR TITLE
Upgrade default Node.js version from 20 to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ jobs:
 |-------|-------------|---------|
 | `source-theme-id` | Theme ID to pull settings from | Uses live theme |
 | `build-command` | Command to build assets before deployment | None |
-| `node-version` | Node.js version to use | `20` |
+| `node-version` | Node.js version to use | `22` |
 | `slack-webhook-url` | Slack webhook URL for notifications | None |
 | `ms-teams-webhook-url` | Microsoft Teams webhook URL for notifications | None |
 | `theme-root` | Directory containing the theme files (useful for compiled themes) | `.` (repository root) |
@@ -166,7 +166,7 @@ If your theme requires compilation:
   if: github.event.action != 'closed'
   uses: actions/setup-node@v5
   with:
-    node-version: '20'
+    node-version: '22'
 
 - name: Install dependencies
   if: github.event.action != 'closed'
@@ -192,7 +192,7 @@ If your build process outputs to a different directory (e.g., `dist`), use `them
   if: github.event.action != 'closed'
   uses: actions/setup-node@v5
   with:
-    node-version: '20'
+    node-version: '22'
 
 - name: Install dependencies
   if: github.event.action != 'closed'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   node-version:
     description: 'Node.js version to use (optional)'
     required: false
-    default: '20'
+    default: '22'
   slack-webhook-url:
     description: 'Slack webhook URL for notifications (optional)'
     required: false

--- a/examples/example.yml
+++ b/examples/example.yml
@@ -39,7 +39,7 @@ jobs:
       #   if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'rebuild-theme')
       #   uses: actions/setup-node@v5
       #   with:
-      #     node-version: '20'  # OPTIONAL: defaults to 20
+      #     node-version: '22'  # OPTIONAL: defaults to 22
       
       # - name: Install dependencies
       #   if: github.event.action != 'closed' && (github.event.action != 'labeled' || github.event.label.name == 'rebuild-theme')
@@ -60,7 +60,7 @@ jobs:
           # build-command: 'npm run build'  # Command to build assets before deployment
           # theme-root: 'dist'  # Directory containing theme files (defaults to '.' repository root)
           # ignore-files: 'templates/page.instant-*.json, sections/instant-*.json'  # Patterns to ignore during upload
-          # node-version: '20'  # Node.js version (defaults to 20)
+          # node-version: '22'  # Node.js version (defaults to 22)
           # slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}  # Slack webhook for notifications
           # ms-teams-webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL }}  # MS Teams webhook for notifications
 


### PR DESCRIPTION
## Summary
Updates the default Node.js version used by the GitHub Action from version 20 to version 22 across all configuration files and documentation.

## Changes Made
- Updated `action.yml` default input value for `node-version` from `'20'` to `'22'`
- Updated README.md documentation:
  - Default value in the inputs table
  - Example workflow configurations (2 instances)
- Updated `examples/example.yml` with the new default version in comments and configuration examples

## Details
This change ensures that new users of this GitHub Action will use Node.js 22 by default, while maintaining backward compatibility for users who explicitly specify a different version. The update is reflected consistently across all documentation and example files to prevent confusion.

https://claude.ai/code/session_012j9vY5qNQVxTpWZ1Uoj6Ro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Node.js version from 20 to 22.

* **Documentation**
  * Updated examples and documentation to reflect the new default Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->